### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tuist Badge](https://img.shields.io/badge/powered%20by-Tuist-green.svg?longCache=true)](https://github.com/tuist)
 
-This repository contains a modular Xcode project built using the [µfeatures](https://docs.tuist.io/building-at-scale/microfeatures/) approach.
+This repository contains a modular Xcode project built using the [TMA](https://docs.tuist.io/guides/develop/projects/tma-architecture) approach.
 
 ## Setup
 1. Git clone the repository: `git clone git@github.com:tuist/microfeatures-example.git`.


### PR DESCRIPTION
The link was pointing to the old micro architecture site that no longer exists.

I changed the name to TMA and decided to leave everything else unchanged. I also considered keeping it `µfeatures` since that's the name of the repo and just change the link, but I wasn't sure, anyways, up to you guys!